### PR TITLE
Enhanced airspace file download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ detailed airspace management for London airports using STARs and SIDs.
 
 Follow these steps to add the custom airspace to your game:
 
-0. Download the `LTCC.ini` file from the [latest release](https://github.com/zefir-git/eatc-ltc/releases/latest) on
-   GitHub.
+0. Download the [`LTCC.ini`](https://github.com/zefir-git/eatc-ltc/releases/latest/download/LTCC.ini) file from the
+   latest release on GitHub.
 
 > [!NOTE]
 > You need the full (paid) version of *Endless ATC*; the demo or lite version will not work.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ detailed airspace management for London airports using STARs and SIDs.
 
 ## Installation
 
+Download the [`LTCC.ini`](https://github.com/zefir-git/eatc-ltc/releases/latest/download/LTCC.ini) file from the
+latest release on GitHub.
+
 <details>
 <summary>Show installation steps</summary>
 
 Follow these steps to add the custom airspace to your game:
-
-0. Download the [`LTCC.ini`](https://github.com/zefir-git/eatc-ltc/releases/latest/download/LTCC.ini) file from the
-   latest release on GitHub.
 
 > [!NOTE]
 > You need the full (paid) version of *Endless ATC*; the demo or lite version will not work.


### PR DESCRIPTION
The README now includes a direct download link to the airspace file from the latest available release.

To improve visibility, the instructions on where to download the file have been moved out of the collapsible `<details>` section and placed at the top of the ‘Installation’ section.

The ‘Installation’ section now focuses solely on the standard Endless ATC custom airspace installation steps.