### PR TITLE
Added RNP approaches for Gatwick 26R/08L

### DIFF
--- a/airspace/EGKK.ts
+++ b/airspace/EGKK.ts
@@ -7,7 +7,6 @@ import SID from "../src/SID.js";
 import NamedFix from "../src/NamedFix.js";
 import fs from "node:fs/promises";
 import Beacon from "../src/Beacon.js";
-import StarFix from "../src/StarFix.js";
 
 export default class EGKK {
 	public async init() {

--- a/airspace/EGKK.ts
+++ b/airspace/EGKK.ts
@@ -912,14 +912,16 @@ export default class EGKK {
 	}
 
 	private rnp() {
-		const kkn = Generator.getInstance().runway("kkn");
+		const rwy26r = Generator.getInstance().runway("kkn");
+		const rwy08l = rwy26r.reverse();
 
-		Generator.getInstance().fix("ARPIT", kkn.position.destination(kkn.reverseLocalizer, 10.6));
+		Generator.getInstance().fix("ARPIT", rwy26r.position.destination(rwy26r.reverseLocalizer, 10.6));
+		Generator.getInstance().fix("MEBIG", rwy08l.position.destination(rwy08l.reverseLocalizer, 10.6));
 
 		Generator.getInstance().arrival(new STAR(
 			"RNP",
 			"R-N-P",
-			[kkn],
+			[rwy26r],
 			false,
 			Beacon.from("ARPIT", "Arpit", Generator.getInstance().fix("ARPIT")),
 			void 0,
@@ -927,6 +929,20 @@ export default class EGKK {
 				Generator.getInstance().fix("ARPIT", 3000)
 			],
 			// K26RF
+			{ils: {dme: 8.6, altitude: 3000}}
+		));
+
+		Generator.getInstance().arrival(new STAR(
+			"RNP",
+			"R-N-P",
+			[rwy26r],
+			"only",
+			Beacon.from("MEBIG", "Mebig", Generator.getInstance().fix("MEBIG")),
+			void 0,
+			[
+				Generator.getInstance().fix("MEBIG", 3000)
+			],
+			// K08LF
 			{ils: {dme: 8.6, altitude: 3000}}
 		));
 	}

--- a/airspace/EGKK.ts
+++ b/airspace/EGKK.ts
@@ -6,12 +6,15 @@ import STAR from "../src/STAR.js";
 import SID from "../src/SID.js";
 import NamedFix from "../src/NamedFix.js";
 import fs from "node:fs/promises";
+import Beacon from "../src/Beacon.js";
+import StarFix from "../src/StarFix.js";
 
 export default class EGKK {
 	public async init() {
 		await this.airport();
 		this.star();
 		this.sid();
+		this.rnp();
 	}
 
 	private async airport() {
@@ -906,6 +909,26 @@ export default class EGKK {
 				Generator.getInstance().fix("DAGGA"),
 				Generator.getInstance().fix("CLN", "515054.50N", "0010851.32E")
 			]
+		));
+	}
+
+	private rnp() {
+		const kkn = Generator.getInstance().runway("kkn");
+
+		Generator.getInstance().fix("ARPIT", kkn.position.destination(kkn.reverseLocalizer, 10.6));
+
+		Generator.getInstance().arrival(new STAR(
+			"RNP",
+			"R-N-P",
+			[kkn],
+			false,
+			Beacon.from("ARPIT", "Arpit", Generator.getInstance().fix("ARPIT")),
+			void 0,
+			[
+				Generator.getInstance().fix("ARPIT", 3000)
+			],
+			// K26RF
+			{ils: {dme: 8.6, altitude: 3000}}
 		));
 	}
 }


### PR DESCRIPTION
Added RNP approaches for the Gatwick secondary runway 26R/08L for realism as this runway has no ILS in real life.

In-game you can still use ILS as before, if you wish.

To clear an aircraft for the RNP approach, select direct ARPIT/MEBIG and enable <kbd>APP</kbd>.