### PR TITLE
Use `.txt` for the file extension

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,5 +36,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: LTCC.ini
-          path: LTCC.ini
+          name: LTCC.txt
+          path: LTCC.txt

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,8 +40,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: LTCC.ini
-          path: LTCC.ini
+          name: LTCC.txt
+          path: LTCC.txt
 
       - name: Upload to release
         uses: cloudnode-pro/release-upload-asset@1.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 dist/
-LTCC.ini
+LTCC.txt

--- a/airspace/index.ts
+++ b/airspace/index.ts
@@ -260,7 +260,7 @@ await new AirspaceLines().withCoastline();
 
 const project = JSON.parse(await fs.readFile("./package.json", "utf8"));
 
-await fs.writeFile("./LTCC.ini", gen.generate(`
+await fs.writeFile("./LTCC.txt", gen.generate(`
 #
 # London Terminal Control for EndlessATC
 # Version: ${project.version}


### PR DESCRIPTION
The mobile app only accepts `.txt` files for importing. This should simplify importing on mobile.