### PR TITLE
Added RNP approaches for EGLL, EGKK, and EGSS

### DIFF
--- a/airspace/EGKK.ts
+++ b/airspace/EGKK.ts
@@ -7,6 +7,7 @@ import SID from "../src/SID.js";
 import NamedFix from "../src/NamedFix.js";
 import fs from "node:fs/promises";
 import Beacon from "../src/Beacon.js";
+import StarFix from "../src/StarFix.js";
 
 export default class EGKK {
 	public async init() {
@@ -994,37 +995,59 @@ export default class EGKK {
 	}
 
 	private rnp() {
-		const rwy26r = Generator.getInstance().runway("kkn");
-		const rwy08l = rwy26r.reverse();
+		const kkn = Generator.getInstance().runway("kkn");
+		const kks = Generator.getInstance().runway("kks");
 
-		Generator.getInstance().fix("ARPIT", rwy26r.position.destination(rwy26r.reverseLocalizer, 10.6));
-		Generator.getInstance().fix("MEBIG", rwy08l.position.destination(rwy08l.reverseLocalizer, 10.6));
+        const ABIBI = Beacon.fromDMS("510627.14N", "0002853.92W", "ABIBI", "Abibi");
+        const OLEVI = Beacon.fromDMS("511117.40N", "0000611.30E", "OLEVI", "Olevi");
+        const MEBIG = Beacon.fromDMS("510632.92N", "0002900.23W", "MEBIG", "Mebig");
+        const ARPIT = Beacon.fromDMS("511119.23N", "0000535.33E", "ARPIT", "Arpit");
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [kks],
+            "only",
+            ABIBI,
+            void 0,
+            [StarFix.from(ABIBI, 3000)],
+            // K08RF
+            {ils: {dme: 8.6, altitude: 3000}}
+        ));
 
 		Generator.getInstance().arrival(new STAR(
 			"RNP",
 			"R-N-P",
-			[rwy26r],
+			[kks],
 			false,
-			Beacon.from("ARPIT", "Arpit", Generator.getInstance().fix("ARPIT")),
+			OLEVI,
 			void 0,
-			[
-				Generator.getInstance().fix("ARPIT", 3000)
-			],
-			// K26RF
+			[StarFix.from(OLEVI, 3000)],
+			// K26LF
 			{ils: {dme: 8.6, altitude: 3000}}
 		));
 
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [kkn],
+            "only",
+            MEBIG,
+            void 0,
+            [StarFix.from(MEBIG, 3000)],
+            // K08LF
+            {ils: {dme: 8.6, altitude: 3000}}
+        ));
+
 		Generator.getInstance().arrival(new STAR(
 			"RNP",
 			"R-N-P",
-			[rwy26r],
-			"only",
-			Beacon.from("MEBIG", "Mebig", Generator.getInstance().fix("MEBIG")),
+			[kkn],
+			false,
+			ARPIT,
 			void 0,
-			[
-				Generator.getInstance().fix("MEBIG", 3000)
-			],
-			// K08LF
+			[StarFix.from(ARPIT, 3000)],
+			// K26RF
 			{ils: {dme: 8.6, altitude: 3000}}
 		));
 	}

--- a/airspace/EGLL.ts
+++ b/airspace/EGLL.ts
@@ -12,6 +12,7 @@ import StarFix from "../src/StarFix.js";
 export default class EGLL {
 	public async init() {
 		await this.airport();
+        this.rnp();
 		this.star();
 		this.sid();
 	}
@@ -670,4 +671,70 @@ export default class EGLL {
 			true
 		));
 	}
+
+    private rnp() {
+        const lln = Generator.getInstance().runway("lln");
+        const lls = Generator.getInstance().runway("lls");
+
+        const ABAVI = Beacon.fromDMS("512834.45N", "0004505.67W", "ABAVI", "Abavi");
+        const BEMPA = Beacon.fromDMS("512748.76N", "0004455.76W", "BENPA", "Benpa");
+        const NEKSA = Beacon.fromDMS("512755.72N", "0001001.89W", "NEKSA", "Neksa");
+        const IVLAR = Beacon.fromDMS("512841.57N", "0001000.08W", "IVLAR", "Ivlar");
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [lln],
+            "only",
+            ABAVI,
+            void 0,
+            [
+                StarFix.from(ABAVI, 3000),
+                Generator.getInstance().fix("L09LF", "512836.05N", "0004015.82W", 2500),
+            ],
+            {ils: {dme: 4, altitude: 1400}}
+        ));
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [lls],
+            "only",
+            BEMPA,
+            void 0,
+            [
+                StarFix.from(BEMPA, 3000),
+                Generator.getInstance().fix("L09RF", "512750.34N", "0004007.13W", 2500),
+            ],
+            {ils: {dme: 4, altitude: 1400}}
+        ));
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [lls],
+            false,
+            NEKSA,
+            void 0,
+            [
+                StarFix.from(NEKSA, 3000),
+                Generator.getInstance().fix("L27LF", "512755.40N", "0001452.50W", 2500)
+            ],
+            {ils: {dme: 4, altitude: 1400}}
+        ));
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP",
+            "R-N-P",
+            [lln],
+            false,
+            IVLAR,
+            void 0,
+            [
+                StarFix.from(IVLAR, 3000),
+                Generator.getInstance().fix("L27RF", "512841.22N", "0001449.66W", 2500),
+            ],
+            {ils: {dme: 4, altitude: 1410}}
+        ));
+    }
 }

--- a/airspace/EGSS.ts
+++ b/airspace/EGSS.ts
@@ -7,12 +7,14 @@ import STAR from "../src/STAR.js";
 import SID from "../src/SID.js";
 import NamedFix from "../src/NamedFix.js";
 import fs from "node:fs/promises";
+import StarFix from "../src/StarFix.js";
 
 export default class EGSS {
 	public async init() {
 		await this.airport();
 		this.star();
 		this.sid();
+        this.rnp();
 	}
 
 	private async airport() {
@@ -543,4 +545,39 @@ export default class EGSS {
 			6000
 		));
 	}
+
+    private rnp() {
+        const rwy = Generator.getInstance().runway("ss");
+
+        const EKVEG = Beacon.fromDMS("514458.16N", "0000156.61E", "EKVEG", "Ekveg");
+        const TOTVO = Beacon.fromDMS("520118.82N", "0002627.79E", "TOTVO", "Totvo");
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP Z",
+            "R-N-P Zulu",
+            [rwy],
+            "only",
+            EKVEG,
+            void 0,
+            [StarFix.from(EKVEG, 2500, 200)],
+            // SS04F
+            {ils: {dme: 6.6, altitude: 2500}}
+        ));
+
+        // RNP Y 04 omitted (maintenance THR)
+
+        Generator.getInstance().arrival(new STAR(
+            "RNP Z",
+            "R-N-P Zulu",
+            [rwy],
+            false,
+            TOTVO,
+            void 0,
+            [StarFix.from(TOTVO, 2500, 200)],
+            // SS22F
+            {ils: {dme: 6.6, altitude: 2500}}
+        ));
+
+        // RNP Y 22 omitted (maintenance THR)
+    }
 }


### PR DESCRIPTION
EGSS RNP Y is omitted because this custom airspace does not use the maintenance offset threshold.